### PR TITLE
add undetermined const to check if file.type is empty

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -82,20 +82,22 @@ export class Header extends Component<HeaderProps, {}> {
     return validJson;
   };
 
+  isNotJsonFile = (mimeType: string) => {
+    return !this.isJsonFile(mimeType);
+  };
+
   handleFileImport = (selectedFile: FileList) => {
+    const undetermined = '';
     const file = selectedFile.item(0);
+    if (file === null) {
+      return;
+    }
+    // continue w/ filereader if file type is undetermined by browser
+    if (file.type !== undetermined && this.isNotJsonFile(file.type)) {
+      return;
+    }
+
     const fileReader = new FileReader();
-
-    if (file == null) {
-      return;
-    }
-
-    if (!this.isJsonFile(file.type)) {
-      // tslint:disable-next-line:no-console
-      console.log('only json allowed');
-      return;
-    }
-
     fileReader.onloadend = () => this.props.templateStore.updateTemplate(fileReader.result);
     fileReader.readAsText(file, 'UTF8');
   };

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -77,26 +77,8 @@ interface HeaderProps {
 }
 
 export class Header extends Component<HeaderProps, {}> {
-  isJsonFile = (mimeType: string) => {
-    const validJson = mimeType.includes('json');
-    return validJson;
-  };
-
-  isNotJsonFile = (mimeType: string) => {
-    return !this.isJsonFile(mimeType);
-  };
-
   handleFileImport = (selectedFile: FileList) => {
-    const undetermined = '';
     const file = selectedFile.item(0);
-    if (file === null) {
-      return;
-    }
-    // continue w/ filereader if file type is undetermined by browser
-    if (file.type !== undetermined && this.isNotJsonFile(file.type)) {
-      return;
-    }
-
     const fileReader = new FileReader();
     fileReader.onloadend = () => this.props.templateStore.updateTemplate(fileReader.result);
     fileReader.readAsText(file, 'UTF8');


### PR DESCRIPTION
From docs (https://developer.mozilla.org/en-US/docs/Web/API/File/type)
"Note: Based on the current implementation, browsers won't actually read the bytestream of a file to determine its media type. It is assumed based on the file extension; a PNG image file renamed to .txt would give "text/plain" and not "image/png". Moreover, file.type is only reliable for common file types like images, documents audio and video. Uncommon file extensions would return an empty string. Developers are advised not to rely on this property as a sole validation scheme."